### PR TITLE
Fix dependency version constraints

### DIFF
--- a/keygen/keygen.cabal
+++ b/keygen/keygen.cabal
@@ -20,8 +20,8 @@ executable keygen
   build-depends:
     base                 >= 4.8 && < 4.13,
     ansi-wl-pprint       >= 0.6.9 && < 0.7,
-    base64-bytestring    >= 0.1 && < 0.2,
-    base16-bytestring    >= 1.0 && < 1.1,
+    base64-bytestring    >= 1.0 && < 1.1,
+    base16-bytestring    >= 0.1 && < 0.2,
     bytestring           >= 0.10 && < 0.11,
     containers           >= 0.5 && < 0.7,
     cryptonite           >= 0.25 && < 0.27,


### PR DESCRIPTION
Ran into this build issue while attempting to build secure-keygen from source:

```
Selected resolver: lts-14.16
Resolver 'lts-14.16' does not have all the packages to match your requirements.
    base16-bytestring version 0.1.1.6 found
        - keygen requires >=1.0 && <1.1
    base64-bytestring version 1.0.0.2 found
        - keygen requires >=0.1 && <0.2

This may be resolved by:
    - Using '--omit-packages' to exclude mismatching package(s).
    - Using '--resolver' to specify a matching snapshot/resolver
```

I think the version constraints for these two packages were flipped, but let me know if that's not the case.